### PR TITLE
About page: move Richard II into NVS coverage table

### DIFF
--- a/index.html
+++ b/index.html
@@ -3308,15 +3308,15 @@
                             <tr><td>18</td><td>King John</td><td>1919</td><td>H.&nbsp;H.&nbsp;Furness&nbsp;Jr.</td></tr>
                             <tr><td>19</td><td>Coriolanus</td><td>1928</td><td>H.&nbsp;H.&nbsp;Furness&nbsp;Jr.</td></tr>
                             <tr><td>20</td><td>Henry IV, Part 1</td><td>1936</td><td>S.&nbsp;B.&nbsp;Hemingway</td></tr>
+                            <tr><td>21</td><td>Richard II</td><td>1955</td><td>M.&nbsp;W.&nbsp;Black</td></tr>
                         </tbody>
                     </table>
 
-                    <p><strong>Three Plays Forthcoming</strong></p>
-                    <p>The following three volumes were available only as limited previews and could not be fully processed. They will be added as access permits.</p>
+                    <p><strong>Two Plays Forthcoming</strong></p>
+                    <p>The following two volumes were available only as limited previews and could not be fully processed. They will be added as access permits.</p>
                     <ul>
                         <li>Henry IV, Part 2 (1940, ed. M.&nbsp;A.&nbsp;Shaaber)</li>
                         <li>Troilus and Cressida (1953, ed. H.&nbsp;N.&nbsp;Hillebrand &amp; T.&nbsp;W.&nbsp;Baldwin)</li>
-                        <li>Richard II (1955, ed. M.&nbsp;W.&nbsp;Black)</li>
                     </ul>
 
                     <p><strong>Non-Dramatic Volumes</strong></p>
@@ -3330,7 +3330,7 @@
                         <tbody>
                             <tr><td>Out-of-copyright NVS plays (total)</td><td>23</td></tr>
                             <tr><td>Plays fully included on this site</td><td>22</td></tr>
-                            <tr><td>Plays forthcoming (limited preview only)</td><td>1</td></tr>
+                            <tr><td>Plays forthcoming (limited preview only)</td><td>2</td></tr>
                             <tr><td>Non-dramatic poetry volumes</td><td>2</td></tr>
                         </tbody>
                     </table>


### PR DESCRIPTION
Added Richard II (1955, M. W. Black) as #21 in the coverage table and removed it from the forthcoming list; adjusted heading and summary counts.